### PR TITLE
78行缺少一个冒号

### DIFF
--- a/ApiGeyserUtils.sk
+++ b/ApiGeyserUtils.sk
@@ -75,7 +75,7 @@ effect add %objects% to [dialogue] %object%:
         loop {_a::*}:
             expr-2.buttons().add(loop-value)
             
-effect close dialogue of %player%
+effect close dialogue of %player%:
     trigger:
         NpcDialogueForm.closeForm(FloodgateApi.getInstance().getPlayer(expr-1.getUniqueId()))
             


### PR DESCRIPTION
如题，不加的话会报错
```
[15:50:43 INFO]: [Skript] Line 79: (ApiGeyserUtils.sk)
[15:50:43 INFO]:     indentation error: expected 0 spaces, but found 4 spaces
[15:50:43 INFO]:     Line: trigger:
[15:50:43 INFO]: [Skript] Line 80: (ApiGeyserUtils.sk)
[15:50:43 INFO]:     indentation error: expected 0 spaces, but found 8 spaces
[15:50:43 INFO]:     Line: NpcDialogueForm.closeForm(FloodgateApi.getInstance().getPlayer(expr-1.getUniqueId()))
[15:50:43 INFO]: [Skript] Line 78: (ApiGeyserUtils.sk)
[15:50:43 INFO]:     invalid line - all code has to be put into triggers
[15:50:43 INFO]:     Line: effect close dialogue of %player%
```